### PR TITLE
Ensure that packet with sequence exists before attempting to calculate BER 

### DIFF
--- a/stats/functions.py
+++ b/stats/functions.py
@@ -139,7 +139,12 @@ def compute_ber(df, PACKET_LEN=32, MAX_SEQ=256):
     # start count the error bits
     for idx in range(packets):
         # return the matched row index for the specific seq number in log file
-        error_idx = error.index[error.seq == df.seq[idx]][0]
+        error_data = error.index[error.seq == df.seq[idx]]
+        if error_data.size == 0:
+            # No packet with this sequence was received.
+            # This will result in the entire packet payload being considered as error (see below)
+            continue
+        error_idx = error_data[0]
         #parse the payload and return a list, each element is 8-bit data, the first 16-bit data is pseudoseq
         payload = parse_payload(df.payload[idx])
         pseudoseq = int(((payload[0]<<8) - 0) + payload[1])


### PR DESCRIPTION
The Jupyter notebook would fail with an index error when calculating the BER in cases where a packet with an expected sequence number was not received (i.e. not found in the log file). This PR adds a check that prevents this error from occurring. The BER should still be calculated  correctly, since an empty `bit_error_tmp`-array will be treated as a lost package. 

Closes #7.